### PR TITLE
stop request if we hit 429

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,8 +17,12 @@ module.exports.rateLimitRedis = async function (options) {
 					res.set('retry-after', result.retry);
 				}
 
-				res.status(result.status);
-				next();
+				if (result.status === 429) {
+					res.status(result.status);
+					res.json({ message: 'Too many requests', retryAfter: result.retry });
+				} else {
+					next();
+				}
 			})
 			.catch(next);
 	};


### PR DESCRIPTION
Hey, thanks for putting up this little lib. 💪 

One change I needed - currently the middleware continues to allow the rest of the request handlers even if the request should be rate-limited. Small update here is to not call `next()` if we're at the limit.